### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "inquirer": "^9.2.12",
     "playwright": "*",
     "prettier": "^3.1.0",
-    "swagger-ui-express": "^5.0.0"
+    "swagger-ui-express": "^5.0.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@apify/tsconfig": "^0.1.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import { readFile } from "fs/promises";
 import { Config, configSchema } from "./config.js";
 import { configDotenv } from "dotenv";
 import swaggerUi from "swagger-ui-express";
+import rateLimit from "express-rate-limit";
 // @ts-ignore
 import swaggerDocument from "../swagger-output.json" assert { type: "json" };
 import CrawlGPTCore from "./core.js";
@@ -15,8 +16,14 @@ const app: Express = express();
 const port = Number(process.env.API_PORT) || 3000;
 const hostname = process.env.API_HOST || "localhost";
 
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
 app.use(cors());
 app.use(express.json());
+app.use(limiter);
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 // Define a POST route to accept config and run the crawler


### PR DESCRIPTION
Potential fix for [https://github.com/khulnasoft/CrawlGPT/security/code-scanning/1](https://github.com/khulnasoft/CrawlGPT/security/code-scanning/1)

To fix the problem, we need to introduce a rate-limiting middleware to the Express application. The `express-rate-limit` package is a well-known library for this purpose. We will configure the rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to all routes, including the `/crawl` route.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `src/server.ts` file.
3. Configure the rate limiter with appropriate settings.
4. Apply the rate limiter middleware to the Express application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
